### PR TITLE
ConfigValueProviderConfigTransformer no longer throws unless set.

### DIFF
--- a/tsc4j-core/src/main/java/com/github/tsc4j/core/Tsc4jImplUtils.java
+++ b/tsc4j-core/src/main/java/com/github/tsc4j/core/Tsc4jImplUtils.java
@@ -1718,6 +1718,7 @@ public class Tsc4jImplUtils {
     private static ConfigTransformer createConfigValueTransformer(@NonNull Collection<ConfigValueProvider> configValueProviders) {
         val transformer = ConfigValueProviderConfigTransformer.builder()
             .withProviders(configValueProviders)
+            .setAllowErrors(true)
             .build();
         log.info("created config transformer from {} value provider(s): {}", configValueProviders.size(), configValueProviders);
         return transformer;

--- a/tsc4j-core/src/main/java/com/github/tsc4j/core/impl/OnlyOnce.java
+++ b/tsc4j-core/src/main/java/com/github/tsc4j/core/impl/OnlyOnce.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 - 2021 tsc4j project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.tsc4j.core.impl;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+
+/**
+ * Set that invokes consumer if given item is seen for the first time.
+ *
+ * @param <T> element type
+ */
+@RequiredArgsConstructor
+public final class OnlyOnce<T> {
+    private final Set<T> set = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * item consumer to run if given item has been first observed.
+     */
+    @NonNull
+    private final Consumer<T> itemConsumer;
+
+    /**
+     * Max items to contain in the set.
+     */
+    private final int maxItems;
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    /**
+     * Runs item consumer if item has not been seen by this set yet.
+     *
+     * @param item item
+     * @return true if given item has been observed for the first time, otherwise false
+     */
+    public boolean add(@NonNull T item) {
+        return add(item, itemConsumer);
+    }
+
+    /**
+     * Runs given item consumer if item has not been seen by this set yet.
+     *
+     * @param item         item
+     * @param itemConsumer consumer to run
+     * @return true if given item has been observed for the first time, otherwise false
+     */
+    public boolean add(@NonNull T item, Consumer<T> itemConsumer) {
+        maybeRunMaintenance();
+
+        val result = set.add(item);
+        if (result) {
+            itemConsumer.accept(item);
+        }
+
+        return result;
+    }
+
+    private void maybeRunMaintenance() {
+        if (counter.incrementAndGet() % 100 == 0) {
+            runMaintenance();
+        }
+    }
+
+    private void runMaintenance() {
+        if (set.size() > maxItems) {
+            clear();
+        }
+    }
+
+    /**
+     * Clears internal set.
+     *
+     * @return reference to itself.
+     */
+    public OnlyOnce<T> clear() {
+        set.clear();
+        return this;
+    }
+}

--- a/tsc4j-core/src/test/java/com/github/tsc4j/core/impl/OnlyOnceSpec.groovy
+++ b/tsc4j-core/src/test/java/com/github/tsc4j/core/impl/OnlyOnceSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 - 2021 tsc4j project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.tsc4j.core.impl
+
+import com.github.tsc4j.core.impl.OnlyOnce
+import groovy.util.logging.Slf4j
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+@Slf4j
+class OnlyOnceSpec extends Specification {
+    def maxItems = 10
+    def invokedWith = []
+    def consumer = {
+        log.debug("invoked with: {}", it)
+        invokedWith.add(it)
+    } as Consumer<String>
+    def set = new OnlyOnce<String>(consumer, maxItems)
+
+    def "should run given consumer only once"() {
+        given:
+        def item = 'foo'
+
+        when:
+        def results = (1..maxItems).collect { set.add(item) }
+
+        then:
+        results.pop() == true
+        results.each { assert it == false }
+
+        invokedWith.size() == 1
+        invokedWith[0] == item
+    }
+
+    def "should perform maintenance if over capacity"() {
+        given:
+        def items = (1..maxItems * 20).collect { "item-$it" }
+
+        when:
+        items.each { set.add(it) }
+
+        then:
+        set.set.size() == 1
+        set.set[0] == 'item-200'
+    }
+}


### PR DESCRIPTION
When `ConfigValueProviderConfigTransformer` sees `ConfigValue` magic
variable that refers to unregistered config value transformer it just
emits warning instead of throwing.