### PR TITLE
AWS SSM parameter store bugfixes

### DIFF
--- a/tsc4j-aws-common/src/main/java/com/github/tsc4j/aws/common/AwsConfig.java
+++ b/tsc4j-aws-common/src/main/java/com/github/tsc4j/aws/common/AwsConfig.java
@@ -94,7 +94,6 @@ public final class AwsConfig implements WithConfig {
     @Override
     public void withConfig(@NonNull Config cfg) {
         cfgBoolean(cfg, "anonymous-auth", this::setAnonymousAuth);
-        cfgBoolean(cfg, "anonymous-auth", this::setAnonymousAuth);
         cfgString(cfg, "access-key-id", this::setAccessKeyId);
         cfgString(cfg, "secret-access-key", this::setSecretAccessKey);
         cfgString(cfg, "region", this::setRegion);

--- a/tsc4j-aws/src/main/java/com/github/tsc4j/aws/sdk1/ParameterStoreConfigSource.java
+++ b/tsc4j-aws/src/main/java/com/github/tsc4j/aws/sdk1/ParameterStoreConfigSource.java
@@ -132,6 +132,7 @@ public final class ParameterStoreConfigSource extends AbstractConfigSource {
         @Override
         public void withConfig(@NonNull Config config) {
             super.withConfig(config);
+            getAwsConfig().withConfig(config);
 
             cfgExtract(config, "paths", Config::getStringList, this::setPaths);
             cfgString(config, "at-path", this::setAtPath);

--- a/tsc4j-aws/src/main/java/com/github/tsc4j/aws/sdk1/ParameterStoreValueProvider.java
+++ b/tsc4j-aws/src/main/java/com/github/tsc4j/aws/sdk1/ParameterStoreValueProvider.java
@@ -108,6 +108,7 @@ public final class ParameterStoreValueProvider extends AbstractConfigValueProvid
         @Override
         public void withConfig(@NonNull Config config) {
             super.withConfig(config);
+            getAwsConfig().withConfig(config);
             
             cfgBoolean(config, "decrypt", this::setDecrypt);
         }


### PR DESCRIPTION
AWS SSM value provider and config source did not observe common aws
parameters (endpoint, region, etc).
