### PR TITLE
ConfigValueProviderTransformer: added ability to tolerate invalid config reference specs

### DIFF
--- a/tsc4j-core/src/main/java/com/github/tsc4j/core/Tsc4jImplUtils.java
+++ b/tsc4j-core/src/main/java/com/github/tsc4j/core/Tsc4jImplUtils.java
@@ -1719,6 +1719,7 @@ public class Tsc4jImplUtils {
         val transformer = ConfigValueProviderConfigTransformer.builder()
             .withProviders(configValueProviders)
             .setAllowErrors(false)
+            .setTolerateBadConfigReferenceValueSpecs(true)
             .build();
         log.info("created config transformer from {} value provider(s): {}", configValueProviders.size(), configValueProviders);
         return transformer;


### PR DESCRIPTION
Sometimes valid loaded configurations contain substrings in a form of
`{foo}`, for example `x: "hello, {name}!"` - in such cases `{name}` was
mistaken for an old-style config value reference specification which has
a syntax of `{provider[:name]://<config value key>}` and exception was
thrown because of this. This format is obsolete and will be removed in
the future.

This PR adds exception in such cases and makes behaviour configurable in
the code.