### PR TITLE
[aws2-sts]: forcibly include aws2 sts webidentity into native-image

### DIFF
--- a/tsc4j-aws2/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-aws2/reflect-config.json
+++ b/tsc4j-aws2/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-aws2/reflect-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name" : "software.amazon.awssdk.services.sts.internal.StsProfileCredentialsProviderFactory",
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory",
+    "allPublicConstructors" : true
+  }
+]

--- a/tsc4j-uberjar/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-uberjar/native-image.properties
+++ b/tsc4j-uberjar/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-uberjar/native-image.properties
@@ -1,3 +1,0 @@
-#Args = \
-#  --initialize-at-build-time=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
-#  --initialize-at-run-time=ch.qos.logback,ch.qos.logback.core.ConsoleAppender

--- a/tsc4j-uberjar/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-uberjar/reflect-config.json
+++ b/tsc4j-uberjar/src/main/resources/META-INF/native-image/com.github.tsc4j/tsc4j-uberjar/reflect-config.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "software.amazon.awssdk.services.sts.internal.StsProfileCredentialsProviderFactory",
-    "allPublicConstructors" : true
-  }
-]


### PR DESCRIPTION
AWS EKS uses web-identity tokens to implement fine-grained ACLs and
support for that feature is part of aws2-sts dependency, but because
it's being loaded using reflection it doesn't get included in the
produced binary by default. This patch forces inclusion into binary by
marking it open for reflective access.
